### PR TITLE
Fix user creation errors

### DIFF
--- a/src/Apache2BasicAuth/Model/User.php
+++ b/src/Apache2BasicAuth/Model/User.php
@@ -191,6 +191,6 @@ class User
      */
     public function formatHT()
     {
-        return "{$this->getUsername()}: {$this->getHash()}";
+        return "{$this->getUsername()}:{$this->getHash()}";
     }
 }

--- a/src/Apache2BasicAuth/Service.php
+++ b/src/Apache2BasicAuth/Service.php
@@ -308,7 +308,7 @@ class Service
      */
     public function persistUser(User $user)
     {
-        $old = clone $this->findUser($user->getUsername());
+        $old = $this->findUser($user->getUsername());
 
         if (null !== $old) {
             foreach ($old->getGroups() as $groupname) {


### PR DESCRIPTION
- Service::persistUser
  clone is user on possible null object.
  removing it as findUser already return a cloned object if found

- User::formatHT
  Removing space causing apache to fail reading passwd file